### PR TITLE
Add: quantity check when adding to cart

### DIFF
--- a/src/Extensions/OrderExtension.php
+++ b/src/Extensions/OrderExtension.php
@@ -11,6 +11,13 @@ use SilverShop\Stock\Exceptions\BuyableNotEnoughStockException;
  */
 class OrderExtension extends DataExtension
 {
+    public function beforeAdd($buyable, $quantity, $filter)
+    {
+        if(!$buyable->canPurchase(null, $quantity)) {
+            throw new BuyableNotEnoughStockException();
+        }
+    }
+
     public function afterAdd($item, $buyable, $quantity, $filter)
     {
         if(!$buyable->canPurchase(null, $item->Quantity)) {


### PR DESCRIPTION
Performed in the beforeAdd() extension point, to get the relevant (stock level) error message rather than the generic "product cannot be added" message.