### PR TITLE
Fix getTotalStockInCarts not working and speed up

### DIFF
--- a/src/Extensions/ProductStockExtension.php
+++ b/src/Extensions/ProductStockExtension.php
@@ -307,7 +307,6 @@ class ProductStockExtension extends DataExtension
             return 'Product';
         }
 
-        // return $this->owner->getClassName();
     }
 
 

--- a/src/Extensions/ProductStockExtension.php
+++ b/src/Extensions/ProductStockExtension.php
@@ -300,13 +300,7 @@ class ProductStockExtension extends DataExtension
      */
     public function getStockBaseIdentifier()
     {
-
-        if($this->owner->isVariation()){
-            return 'ProductVariation';
-        } else {
-            return 'Product';
-        }
-
+        return $this->owner->getClassName();
     }
 
 

--- a/src/Extensions/ProductStockExtension.php
+++ b/src/Extensions/ProductStockExtension.php
@@ -143,25 +143,35 @@ class ProductStockExtension extends DataExtension
      *
      * @return boolean
      */
+    private static $cached_available_stock = [];
+
     public function hasAvailableStock($require = 1)
     {
+        if( isset(self::$cached_available_stock[$this->owner->ID]) ){
+           return self::$cached_available_stock[$this->owner->ID];
+        }
+
         if ($this->hasVariations()) {
             $stock = false;
 
             foreach ($this->owner->Variations() as $variation) {
                 if ($variation->hasAvailableStock($require)) {
+                    self::$cached_available_stock[$this->owner->ID] = true;
                     return true;
                 }
             }
         }
 
         if ($this->hasWarehouseWithUnlimitedStock()) {
+            self::$cached_available_stock[$this->owner->ID] = true;
             return true;
         } else {
             $stock = $this->getWarehouseStockQuantity();
             $pending = $this->getTotalStockInCarts();
 
-            return ($stock - $pending) >= $require;
+            $result = ($stock - $pending) >= $require;
+            self::$cached_available_stock[$this->owner->ID] = $result;
+            return $result;
         }
     }
 
@@ -173,6 +183,7 @@ class ProductStockExtension extends DataExtension
      */
     public function getTotalStockInCarts()
     {
+        return 0;
         $current = ShoppingCart::curr();
 
         $cartID = 0;

--- a/src/Extensions/ProductStockExtension.php
+++ b/src/Extensions/ProductStockExtension.php
@@ -143,34 +143,25 @@ class ProductStockExtension extends DataExtension
      *
      * @return boolean
      */
-    private static $cached_available_stock = [];
-
     public function hasAvailableStock($require = 1)
     {
-        if( isset(self::$cached_available_stock[$this->owner->ID]) ){
-           return self::$cached_available_stock[$this->owner->ID];
-        }
-
         if ($this->hasVariations()) {
             $stock = false;
 
             foreach ($this->owner->Variations() as $variation) {
                 if ($variation->hasAvailableStock($require)) {
-                    self::$cached_available_stock[$this->owner->ID] = true;
                     return true;
                 }
             }
         }
 
         if ($this->hasWarehouseWithUnlimitedStock()) {
-            self::$cached_available_stock[$this->owner->ID] = true;
             return true;
         } else {
             $stock = $this->getWarehouseStockQuantity();
             $pending = $this->getTotalStockInCarts();
 
             $result = ($stock - $pending) >= $require;
-            self::$cached_available_stock[$this->owner->ID] = $result;
             return $result;
         }
     }

--- a/src/Extensions/ProductStockExtension.php
+++ b/src/Extensions/ProductStockExtension.php
@@ -257,6 +257,7 @@ class ProductStockExtension extends DataExtension
      */
     public function canPurchase($member = null, $quantity = 1)
     {
+
         if($this->getWarehouseStock()->count() < 1) {
             // no warehouses available.
             return true;

--- a/src/Extensions/ProductStockExtension.php
+++ b/src/Extensions/ProductStockExtension.php
@@ -14,6 +14,7 @@ use SilverStripe\Forms\GridField\GridFieldButtonRow;
 use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\ORM\DB;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverShop\Stock\Model\ProductWarehouseStock;
@@ -173,31 +174,38 @@ class ProductStockExtension extends DataExtension
     public function getTotalStockInCarts()
     {
         $current = ShoppingCart::curr();
-        $extra = "";
 
-        if ($current) {
-            $extra = "AND \"ID\" != '$current->ID'";
+        $cartID = 0;
+        if( $current ){
+            $cartID = $current->ID;
         }
 
-        $pending = Order::get()->where("\"Status\" = 'Cart' $extra");
-        $used = 0;
-        $identifier = $this->getStockBaseIdentifier();
-
-        if ($identifier !== "ProductVariation") {
+        if($this->owner->isVariation()){
+            $identifier = "Variation";
+            $identifier2 = "ProductVariation";
+        } else {
             $identifier = "Product";
+            $identifier2 = "Product";
         }
 
-        $key = "{$identifier}ID";
+        $query = 'SELECT SUM(SilverShop_OrderItem.Quantity) AS QuantitySum
+                        FROM SilverShop_OrderItem
+                        LEFT JOIN SilverShop_'.$identifier.'_OrderItem ON SilverShop_'.$identifier.'_OrderItem.ID = SilverShop_OrderItem.ID
+                        LEFT JOIN SilverShop_OrderAttribute ON SilverShop_OrderAttribute.ID=SilverShop_OrderItem.ID
+                        LEFT JOIN SilverShop_Order ON SilverShop_Order.ID=SilverShop_OrderAttribute.OrderID
+                        WHERE SilverShop_'.$identifier.'_OrderItem.'.$identifier2.'ID = ' . $this->owner->ID . '
+                        AND SilverShop_Order.ID != ' . $cartID . '
+                        AND SilverShop_Order.Status=\'Cart\'
+                        GROUP BY SilverShop_'.$identifier.'_OrderItem.'.$identifier2.'ID';
 
-        foreach ($pending as $order) {
-            foreach ($order->Items() as $item) {
-                if ($item->$key == $this->owner->ID) {
-                    $used += $item->Quantity;
-                }
-            }
+        $result = DB::query($query)->next();
+
+        if( $result ){
+            return $result['QuantitySum'];
         }
 
-        return $used;
+        return 0;
+
     }
 
     /**
@@ -218,7 +226,7 @@ class ProductStockExtension extends DataExtension
     {
         return ProductWarehouseStock::get()->filter([
             'ProductID' => $this->owner->ID,
-            'ProductClass' => $this->getStockBaseIdentifier()
+            'ProductClass' => $this->owner->getClassName()
         ]);
     }
 
@@ -292,7 +300,14 @@ class ProductStockExtension extends DataExtension
      */
     public function getStockBaseIdentifier()
     {
-        return $this->owner->getClassName();
+
+        if($this->owner->isVariation()){
+            return 'ProductVariation';
+        } else {
+            return 'Product';
+        }
+
+        // return $this->owner->getClassName();
     }
 
 

--- a/src/Extensions/ProductStockExtension.php
+++ b/src/Extensions/ProductStockExtension.php
@@ -183,7 +183,6 @@ class ProductStockExtension extends DataExtension
      */
     public function getTotalStockInCarts()
     {
-        return 0;
         $current = ShoppingCart::curr();
 
         $cartID = 0;

--- a/tests/unit/ShopStockTest.php
+++ b/tests/unit/ShopStockTest.php
@@ -80,7 +80,7 @@ class ShopStockTest extends SapphireTest
         $this->setStockFor($this->ballRedSmall, 5);
 
         $orderItem = $orderItem->newClassInstance(VariationOrderItem::class);
-        $orderItem->VariationID = $this->ballRedSmall->ID;
+        $orderItem->ProductVariationID = $this->ballRedSmall->ID;
         $orderItem->write();
 
         $this->assertEquals(5, $this->ballRedSmall->getTotalStockInCarts());


### PR DESCRIPTION
Using getClassName to identify Product or ProductVariation is not working because of namespacing.
Speed up TotalStockInCarts by using single Query instead of loop on all carts. 
Tends to be slow if many carts are added.