### PR TITLE
Remove unused v5 deprecated code:  $base = ClassInfo::baseDataClass

### DIFF
--- a/src/Forms/GridFieldProductStockField.php
+++ b/src/Forms/GridFieldProductStockField.php
@@ -18,7 +18,6 @@ class GridFieldProductStockField implements GridField_SaveHandler
     public function handleSave(GridField $grid, DataObjectInterface $record)
     {
         $data = $grid->Value();
-        $base = ClassInfo::baseDataClass($record);
 
         if (isset($data['GridFieldEditableColumns'])) {
             // go through every warehouse and make sure the have either 0 stock


### PR DESCRIPTION
Remove unused v5 deprecated code: 
$base = ClassInfo::baseDataClass($record);

Combined with SS5 this gives an error. In SS4 $base variable is not used.
So the entire line of code can be removed.