### PR TITLE
Lower PHP requirement to ^8.3 to match SS6 framework constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
       "homepage": "https://github.com/silvershop/silvershop-stock/graphs/contributors"
     }],
 	"require": {
-		"php": "^8.4",
+		"php": "^8.3",
 		"silverstripe/framework": "^6.0",
 		"silvershop/core": "^6"
 	},


### PR DESCRIPTION
doesn't need to be 8.4